### PR TITLE
Add Kafka user authentication

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # .env
-KAFKA_USER=admin
+KAFKA_USERNAME=admin
 KAFKA_PASSWORD=admin-secret

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ KAFKA_PASSWORD=admin-secret
 
 Docker Compose charge automatiquement ces variables pour les conteneurs ayant besoin de se connecter à Kafka.
 
+Le broker Kafka utilise le fichier `kafka_server_jaas.conf` fourni dans
+`certs/kafka/`. Celui-ci contient les sections `KafkaServer` et `Client` afin de
+permettre l'authentification SASL/PLAIN et la connexion à Zookeeper.
+
 ## Arborescence
 
 - `log_generation.py` : générateur de logs simple envoyé sur la sortie standard.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ Il est également possible de tester les scripts sans Docker :
 
 Les statistiques seront ajoutées dans le fichier `results.txt` toutes les minutes.
 
+## Configuration de l'authentification Kafka
+
+Les services utilisent désormais l'authentification SASL/PLAIN en plus du SSL. Les identifiants sont renseignés dans le fichier `.env` :
+
+```bash
+KAFKA_USERNAME=admin
+KAFKA_PASSWORD=admin-secret
+```
+
+Docker Compose charge automatiquement ces variables pour les conteneurs ayant besoin de se connecter à Kafka.
+
 ## Arborescence
 
 - `log_generation.py` : générateur de logs simple envoyé sur la sortie standard.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ KAFKA_PASSWORD=admin-secret
 Docker Compose charge automatiquement ces variables pour les conteneurs ayant besoin de se connecter à Kafka.
 
 Le broker Kafka utilise le fichier `kafka_server_jaas.conf` fourni dans
-`certs/kafka/`. Celui-ci contient les sections `KafkaServer` et `Client` afin de
-permettre l'authentification SASL/PLAIN et la connexion à Zookeeper.
+`certs/kafka/`. Celui-ci définit la section `KafkaServer` pour l'authentification
+SASL/PLAIN du broker. La connexion à Zookeeper reste non authentifiée et
+Kafka est lancé avec l'option `-Dzookeeper.sasl.client=false` pour ne pas tenter
+d'utiliser SASL avec Zookeeper.
 
 ## Arborescence
 

--- a/certs/kafka/client.properties
+++ b/certs/kafka/client.properties
@@ -1,10 +1,13 @@
-security.protocol=SSL
+security.protocol=SASL_SSL
 ssl.truststore.location=/etc/kafka/secrets/server.truststore.jks
 ssl.truststore.password=changeit
 
 ssl.keystore.location=/etc/kafka/secrets/client.keystore.jks
 ssl.keystore.password=changeit
 ssl.key.password=changeit
+
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";
 
 # Si vous n’avez pas besoin de vérifier le CN du broker, décommentez :
 # ssl.endpoint.identification.algorithm=

--- a/certs/kafka/kafka_server_jaas.conf
+++ b/certs/kafka/kafka_server_jaas.conf
@@ -1,0 +1,6 @@
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret"
+  user_admin="admin-secret";
+};

--- a/certs/kafka/kafka_server_jaas.conf
+++ b/certs/kafka/kafka_server_jaas.conf
@@ -4,9 +4,3 @@ KafkaServer {
   password="admin-secret"
   user_admin="admin-secret";
 };
-
-Client {
-  org.apache.kafka.common.security.plain.PlainLoginModule required
-  username="admin"
-  password="admin-secret";
-};

--- a/certs/kafka/kafka_server_jaas.conf
+++ b/certs/kafka/kafka_server_jaas.conf
@@ -4,3 +4,9 @@ KafkaServer {
   password="admin-secret"
   user_admin="admin-secret";
 };
+
+Client {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret";
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: SASL_SSL
       KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
       KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
-      KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/secrets/kafka_server_jaas.conf
+      KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/secrets/kafka_server_jaas.conf -Dzookeeper.sasl.client=false
       KAFKA_SSL_KEYSTORE_FILENAME: server.keystore.jks
       KAFKA_SSL_TRUSTSTORE_FILENAME: server.truststore.jks
       KAFKA_SSL_KEYSTORE_CREDENTIALS: credentials.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,13 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: SSL://kafka:9093
-      KAFKA_LISTENERS: SSL://0.0.0.0:9093
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: SSL:SSL
-      KAFKA_INTER_BROKER_LISTENER_NAME: SSL
+      KAFKA_ADVERTISED_LISTENERS: SASL_SSL://kafka:9093
+      KAFKA_LISTENERS: SASL_SSL://0.0.0.0:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: SASL_SSL:SASL_SSL
+      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_SSL
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/secrets/kafka_server_jaas.conf
       KAFKA_SSL_KEYSTORE_FILENAME: server.keystore.jks
       KAFKA_SSL_TRUSTSTORE_FILENAME: server.truststore.jks
       KAFKA_SSL_KEYSTORE_CREDENTIALS: credentials.txt
@@ -77,17 +80,21 @@ services:
       - KAFKA_CLUSTERS_0_NAME=Kafka
       - KAFKA_CLUSTERS_0_BOOTSTRAP_SERVERS=kafka:9093
       - KAFKA_CLUSTERS_0_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_CLUSTERS_0_PROPERTIES_SECURITY_PROTOCOL=SSL
+      - KAFKA_CLUSTERS_0_PROPERTIES_SECURITY_PROTOCOL=SASL_SSL
       - KAFKA_CLUSTERS_0_PROPERTIES_SSL_TRUSTSTORE_LOCATION=/certs/kafka/server.truststore.jks
       - KAFKA_CLUSTERS_0_PROPERTIES_SSL_TRUSTSTORE_PASSWORD=changeit
       # — keystore (présente le certif client) —
       - KAFKA_CLUSTERS_0_PROPERTIES_SSL_KEYSTORE_LOCATION=/certs/kafka/client.keystore.jks
       - KAFKA_CLUSTERS_0_PROPERTIES_SSL_KEYSTORE_PASSWORD=changeit
       - KAFKA_CLUSTERS_0_PROPERTIES_SSL_KEY_PASSWORD=changeit
+      - KAFKA_CLUSTERS_0_PROPERTIES_SASL_MECHANISM=PLAIN
+      - KAFKA_CLUSTERS_0_PROPERTIES_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"${KAFKA_USERNAME}\" password=\"${KAFKA_PASSWORD}\";
       # (optionnel) désactive la vérification du CN si besoin
       - KAFKA_CLUSTERS_0_PROPERTIES_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM=
     volumes:
       - ./certs/kafka:/certs/kafka:ro
+    env_file:
+      - .env
     networks:
       - traitements_distrib
 
@@ -100,13 +107,16 @@ services:
       - kafka
     environment:
       KAFKA_BROKER: kafka:9093
-      KAFKA_SECURITY_PROTOCOL: SSL
+      KAFKA_SECURITY_PROTOCOL: SASL_SSL
       KAFKA_SSL_CAFILE: /certs/kafka/ca.crt
       KAFKA_SSL_CERTFILE: /certs/kafka/client.crt
       KAFKA_SSL_KEYFILE: /certs/kafka/client.key
+      KAFKA_SASL_MECHANISM: PLAIN
     volumes:
       - ./log_generator/app:/app
       - ./certs/kafka:/certs/kafka:ro
+    env_file:
+      - .env
     networks:
       - traitements_distrib
     command: |
@@ -121,15 +131,18 @@ services:
       - kafka
     environment:
       KAFKA_BROKER: kafka:9093
-      KAFKA_SECURITY_PROTOCOL: SSL
+      KAFKA_SECURITY_PROTOCOL: SASL_SSL
       KAFKA_SSL_TRUSTSTORE_LOCATION: /certs/kafka/server.truststore.jks
       KAFKA_SSL_TRUSTSTORE_PASSWORD: changeit
       KAFKA_SSL_KEYSTORE_LOCATION: /certs/kafka/server.keystore.jks
       KAFKA_SSL_KEYSTORE_PASSWORD: changeit
+      KAFKA_SASL_MECHANISM: PLAIN
     networks:
       - traitements_distrib
     volumes:
       - ./certs/kafka:/certs/kafka:ro
+    env_file:
+      - .env
     command: |
       sh -c "sleep 30 && spark-submit --packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.5 /app/log_analysis_complete.py"
 
@@ -146,6 +159,10 @@ services:
       - ./certs/kafka:/certs/kafka:ro
     command:
       - --kafka.server=kafka:9093
+      - --sasl.enabled
+      - --sasl.mechanism=plain
+      - --sasl.username=${KAFKA_USERNAME}
+      - --sasl.password=${KAFKA_PASSWORD}
       # Activation TLS
       - --tls.enabled
       # Chemin vers le fichier CA
@@ -162,6 +179,8 @@ services:
       - --tls.server-name=kafka
 
     restart: always
+    env_file:
+      - .env
     networks:
       - traitements_distrib
     

--- a/log_generator/app/log_generation_complete.py
+++ b/log_generator/app/log_generation_complete.py
@@ -60,6 +60,9 @@ def main():
     ssl_cafile = os.getenv("KAFKA_SSL_CAFILE")
     ssl_certfile = os.getenv("KAFKA_SSL_CERTFILE")
     ssl_keyfile = os.getenv("KAFKA_SSL_KEYFILE")
+    sasl_mechanism = os.getenv("KAFKA_SASL_MECHANISM")
+    username = os.getenv("KAFKA_USERNAME")
+    password = os.getenv("KAFKA_PASSWORD")
     try:
         producer = KafkaProducer(
             bootstrap_servers=[args.kafka_broker],
@@ -71,7 +74,10 @@ def main():
             security_protocol=security_protocol,
             ssl_cafile=ssl_cafile,
             ssl_certfile=ssl_certfile,
-            ssl_keyfile=ssl_keyfile
+            ssl_keyfile=ssl_keyfile,
+            sasl_mechanism=sasl_mechanism,
+            sasl_plain_username=username,
+            sasl_plain_password=password
         )
     except Exception as e:
         print(f"Erreur lors de la connexion à Kafka: {e}")

--- a/spark/app/log_analysis_complete.py
+++ b/spark/app/log_analysis_complete.py
@@ -32,6 +32,13 @@ def connect_to_kafka(spark, kafka_brokers, topic):
         if ks and ksp:
             reader = reader.option("kafka.ssl.keystore.location", ks)
             reader = reader.option("kafka.ssl.keystore.password", ksp)
+        mech = os.getenv("KAFKA_SASL_MECHANISM")
+        user = os.getenv("KAFKA_USERNAME")
+        pwd = os.getenv("KAFKA_PASSWORD")
+        if mech and user and pwd:
+            reader = reader.option("kafka.sasl.mechanism", mech)
+            jaas = f"org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{user}\" password=\"{pwd}\";"
+            reader = reader.option("kafka.sasl.jaas.config", jaas)
 
     df = reader.load()
     return df
@@ -146,6 +153,13 @@ def process_batch(batch_df, batch_id, spark, kafka_brokers, alerts_topic, thresh
             if ks and ksp:
                 writer = writer.option("kafka.ssl.keystore.location", ks)
                 writer = writer.option("kafka.ssl.keystore.password", ksp)
+            mech = os.getenv("KAFKA_SASL_MECHANISM")
+            user = os.getenv("KAFKA_USERNAME")
+            pwd = os.getenv("KAFKA_PASSWORD")
+            if mech and user and pwd:
+                writer = writer.option("kafka.sasl.mechanism", mech)
+                jaas = f"org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{user}\" password=\"{pwd}\";"
+                writer = writer.option("kafka.sasl.jaas.config", jaas)
 
         writer.mode("append").save()
 


### PR DESCRIPTION
## Summary
- add username and password variables in `.env`
- configure Kafka broker for SASL/PLAIN on SSL
- update client properties for authentication
- add JAAS config for Kafka
- enable SASL credentials in Python producer and Spark job
- document authentication setup in README

## Testing
- `python -m py_compile log_generator/app/log_generation_complete.py spark/app/log_analysis_complete.py`

------
https://chatgpt.com/codex/tasks/task_e_68768d306ba4832ba0a4411f2535a7a3